### PR TITLE
Document how to run the app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ For repo access, ask [any repo member](https://github.com/sthlmrb?tab=members). 
 For Heroku (deployment) access, ask [Henrik Nyh](http://henrik.nyh.se).
 
 For DNS changes to `stockholmruby.com` and `stockholmruby.se`, talk to [Barsoom](http://barsoom.se).
+
+
+## Setup
+
+To run the app locally you must first find [your Meetup API key](http://www.meetup.com/meetup_api/key/). Set the `MEETUP_KEY` environment variable.
+
+    % export MEETUP_KEY=...
+
+Now you can set up the app as normal:
+
+    % bundle install
+    % rackup
+
+It is now running on [http://localhost:9292/](http://localhost:9292).
+
+    % open http://localhost:9292/


### PR DESCRIPTION
This app depends on the `MEETUP_KEY` environment variable and can be run
using rackup. It opens on port 9292. Document all of this so others can
get up and running with minimal effort.
