### PR TITLE
Added Cache-Control headers.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,16 +4,18 @@ Bundler.require :default, (ENV["RACK_ENV"] || "development").to_sym
 
 require_relative "meetup"
 
+set :static_cache_control, [:public, max_age: 3600]
+
+before do
+  cache_control :public, max_age: 600
+end
+
 get "/styles.css" do
   scss :styles
 end
 
 get "/" do
-  events = Meetup.upcoming(5)
-  slim :index, locals: {
-    next_event: events.first,
-    more_events: events[1..-1]
-  }
+  slim :index, locals: event_data
 end
 
 get "/organize" do
@@ -22,4 +24,13 @@ end
 
 get "/work" do
   slim :work
+end
+
+def event_data
+  events = Meetup.upcoming(5)
+
+  {
+    next_event: events.first,
+    more_events: events[1..-1]
+  }
 end


### PR DESCRIPTION
#### Cache headers
- Static assets are cached for one hour.
- The routes are cached for 10 minutes by default.
#### Extracted method
- `event_data`

We should probably cache the data returned from Meetup.
_(I prefer to use Redis instead of Memcached)_

:neckbeard:
