### PR TITLE
Improve small screen experience

### DIFF
--- a/views/layout.slim
+++ b/views/layout.slim
@@ -2,6 +2,7 @@ doctype html
 html
   head
     meta charset="utf-8"
+    meta name="viewport" content="width=device-width"
     title= @title || "Stockholm Ruby"
     link href="/styles.css" rel="stylesheet"
     link href="http://fonts.googleapis.com/css?family=Lato:400,400italic,700,900" rel="stylesheet"

--- a/views/styles.scss
+++ b/views/styles.scss
@@ -18,7 +18,7 @@ $xlarge: 45px;
 }
 
 body {
-  padding: 30px 40px;
+  padding: 30px 10px;
   font-family: 'Lato', sans-serif;
   font-size: $medium;
   font-weight: 400;
@@ -49,10 +49,12 @@ a {
 
 nav {
   @include small-text;
-  margin: 30px 0;
+  margin: 20px 0;
 
   a {
     border-bottom: none;
+    display: inline-block;
+    padding: 10px;
     &:hover { color: darken($red, 15%); }
   }
 
@@ -67,11 +69,12 @@ nav {
   }
   li {
     display: inline;
-    margin: 0 20px;
+    margin: 0 10px;
   }
 }
 
 .logo {
+  max-width: 100%;
   width: 300px;
 }
 
@@ -102,7 +105,7 @@ footer {
 
 
 section {
-  margin: 50px 0;
+  margin: 40px 0;
 }
 
 .page-title {


### PR DESCRIPTION
Not perfect, but a couple of quick improvements.
- Add device-width viewport
- Add max-width on logo
- Increase menu links click/touch area

References: #22 (Improve on iPhone)

![1](https://f.cloud.github.com/assets/1955/1332192/c74ee46c-3574-11e3-94dc-5e49d74f648a.png)
![2](https://f.cloud.github.com/assets/1955/1332187/c724bcc8-3574-11e3-8449-02300321aa67.png)
![3](https://f.cloud.github.com/assets/1955/1332189/c74a5442-3574-11e3-8f51-ddc7b592fb6b.png)
![5](https://f.cloud.github.com/assets/1955/1332190/c74d0d68-3574-11e3-8905-9372ded32a66.png)
![4](https://f.cloud.github.com/assets/1955/1332191/c74ee4c6-3574-11e3-8543-f066d085dc2e.png)
