### PR TITLE
Update thoughtbot Upcase link(s)

### DIFF
--- a/views/learn.slim
+++ b/views/learn.slim
@@ -31,6 +31,7 @@ section
     ### Other online resources for Rails
 
     * [Michael Hartl's Rails tutorial](http://ruby.railstutorial.org/ruby-on-rails-tutorial-book), very popular.
+    * thoughtbot has "trails" for [learning Ruby on Rails](https://thoughtbot.com/upcase/rails).
 
     ### Books
 
@@ -39,4 +40,4 @@ section
 
     ### Miscellaneous
 
-    * Thoughtbot has "trail maps" for [learning Ruby](https://upcase.com/ruby) and [learning Rails](https://upcase.com/rails).
+    * Meet [thoughtbot Stockholm Rails developers](https://thoughtbot.com/stockholm) for fika and to talk programming.


### PR DESCRIPTION
* upcase.com now redirects to thoughtbot.com/upcase
* upcase/ruby now redirects to upcase/rails
* move upcase to online learning section
* offer to meet for fika anytime