### PR TITLE
Replace Lato with system fonts for quicker loading

### DIFF
--- a/views/layout.slim
+++ b/views/layout.slim
@@ -5,7 +5,6 @@ html
     meta name="viewport" content="width=device-width"
     title= @title || "Stockholm Ruby"
     link href="/styles.css" rel="stylesheet"
-    link href="http://fonts.googleapis.com/css?family=Lato:400,400italic,700,900" rel="stylesheet"
     javascript:
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/views/styles.scss
+++ b/views/styles.scss
@@ -55,6 +55,7 @@ a {
   a {
     border-bottom: none;
     color: $hashtag-color;
+    letter-spacing: 1px;
     &:hover { color: darken($hashtag-color, 20%); }
   }
 }
@@ -66,6 +67,7 @@ nav {
   a {
     border-bottom: none;
     display: inline-block;
+    letter-spacing: 1px;
     padding: 10px;
     &:hover { color: darken($red, 15%); }
   }
@@ -93,6 +95,7 @@ nav {
 h1 {
   font-size: $xlarge;
   font-weight: 700;
+  letter-spacing: 1px;
   margin-top: -20px;
   margin-bottom: 10px;
 }

--- a/views/styles.scss
+++ b/views/styles.scss
@@ -19,7 +19,8 @@ $xlarge: 45px;
 
 body {
   padding: 30px 10px;
-  font-family: 'Lato', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+               sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: $medium;
   font-weight: 400;
 }
@@ -91,7 +92,7 @@ nav {
 
 h1 {
   font-size: $xlarge;
-  font-weight: 900;
+  font-weight: 700;
   margin-top: -20px;
   margin-bottom: 10px;
 }


### PR DESCRIPTION
Suggestion to go the GitHub route and use systems fonts to avoid downloading a font for the site.

I adopted the font weight on `h1` elements (which must've not worked before). In my opinion it also look better if we go from 700 weight to 600 for bold elements (e.g. navigation and the hash-tag), but I have not tested this on other OS so I left it out of this PR.

#### BEFORE (on MacOS)

![sthlmrb-font-lato](https://cloud.githubusercontent.com/assets/1955/21919030/96080070-d957-11e6-98da-80bf72e1f2f5.png)

#### AFTER (on MacOS)

![sthlmrb-font-system](https://cloud.githubusercontent.com/assets/1955/21919037/9bfc7150-d957-11e6-9030-95c32142c2a4.png)
