### PR TITLE
Add Revelry's "A Beginner's Guide to Ruby on Rails"

### DIFF
--- a/views/learn.slim
+++ b/views/learn.slim
@@ -32,6 +32,7 @@ section
 
     * [Michael Hartl's Rails tutorial](http://ruby.railstutorial.org/ruby-on-rails-tutorial-book), very popular.
     * thoughtbot has "trails" for [learning Ruby on Rails](https://thoughtbot.com/upcase/rails).
+    * [Revelry's - A Beginner's Guide to Ruby on Rails](https://revelry.co/rails-beginners-guide/)
 
     ### Books
 


### PR DESCRIPTION
I received an email from someone who had used `/learn` and the resources
it lays out, and wanted to recommend a new one that they found helpful.

This PR adds that resource.