### PR TITLE
Fix Meetup icon size in navigation

### DIFF
--- a/views/styles.scss
+++ b/views/styles.scss
@@ -83,7 +83,8 @@ nav {
 
   .menu-events {
     background: url(http://www.meetup.com/favicon.ico) no-repeat left center;
-    padding-left: 20px;
+    background-size: 20px 20px;
+    padding-left: 25px;
   }
 }
 


### PR DESCRIPTION
Before:

<img width="400" alt="Screenshot 2022-08-29 at 11 23 04" src="https://user-images.githubusercontent.com/22144/187169216-cc7e5d1f-f102-4a5d-9e0b-8756d2ca3165.png">

After:

<img width="400" alt="Screenshot 2022-08-29 at 11 23 53" src="https://user-images.githubusercontent.com/22144/187169328-240122fc-7716-49b9-9d57-2e84fc102863.png">


